### PR TITLE
fix: pin @actions/core to 1.x to unblock Update Athlete YTD action

### DIFF
--- a/github-actions/package-lock.json
+++ b/github-actions/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@actions/core": "^3.0.1",
+        "@actions/core": "^1.11.1",
         "simple-git": "^3.5.0"
       },
       "devDependencies": {
@@ -28,38 +28,38 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^3.0.0",
-        "@actions/http-client": "^4.0.0"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^3.0.2"
+        "@actions/io": "^1.0.1"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
-      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
+        "undici": "^5.25.4"
       }
     },
     "node_modules/@actions/io": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -1849,6 +1849,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -7368,12 +7377,15 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=14.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -7654,35 +7666,35 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "requires": {
-        "@actions/exec": "^3.0.0",
-        "@actions/http-client": "^4.0.0"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
       }
     },
     "@actions/exec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "requires": {
-        "@actions/io": "^3.0.2"
+        "@actions/io": "^1.0.1"
       }
     },
     "@actions/http-client": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
-      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "requires": {
         "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
+        "undici": "^5.25.4"
       }
     },
     "@actions/io": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
     "@babel/code-frame": {
       "version": "7.29.7",
@@ -8911,6 +8923,11 @@
           "dev": true
         }
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -12895,9 +12912,12 @@
       }
     },
     "undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/github-actions/package.json
+++ b/github-actions/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@actions/core": "^3.0.1",
+    "@actions/core": "^1.11.1",
     "simple-git": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@actions/core 3.x is ESM-only (exports has only an `import` condition), which breaks the CommonJS `require()` in the compiled GitHub Action with ERR_PACKAGE_PATH_NOT_EXPORTED. Revert just this dependency to ^1.11.1 while keeping the rest of #101. Re-pins undici to 5.x (audit finding), but it's only reachable via @actions/http-client, which this code's use of core (info/setOutput/setFailed) never exercises.