### PR TITLE
fix(deps): raise postcss past the source-map path traversal advisory

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -38,7 +38,7 @@
         "globals": "^14.0.0",
         "jest": "^29.0.0",
         "jest-environment-jsdom": "^29.0.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.18",
         "tailwindcss": "^3.0.18",
         "typescript": "^5.0.2"
       }
@@ -10125,9 +10125,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10730,9 +10730,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -10749,7 +10749,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -42,12 +42,12 @@
     "eslint-config-airbnb-typescript": "^16.1.0",
     "eslint-config-next": "^16.0.0",
     "jest": "^29.0.0",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "tailwindcss": "^3.0.18",
     "typescript": "^5.0.2"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Why

In `app/`, `postcss` resolved to **8.5.15**, inside the `<=8.5.17` range of [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — postcss auto-loads a previous source map from `sourceMappingURL`, and the path can be walked out of the project directory to disclose arbitrary `.map` files. High severity, and a **runtime** dependency.

Both the override and the direct devDependency were floored at `^8.5.10`. Both needed raising — npm rejects an override that doesn't match the direct dependency (`EOVERRIDE`):

```diff
 "devDependencies": {
-  "postcss": "^8.5.10",
+  "postcss": "^8.5.18",
 },
 "overrides": {
-  "postcss": "^8.5.10",
+  "postcss": "^8.5.18",
   "uuid": "^11.1.1"
 }
```

## Result

Resolves to **8.5.24**. Production advisories in `app/` **3 → 2**.

The remaining runtime advisory is `sharp` (libvips CVEs). A fix exists in sharp 0.35.0, but `next` declares `optionalDependencies: { "sharp": "^0.34.5" }`, so no Next 16.x accepts it — forcing it via override would be an unsupported combination. Left alone deliberately.

`github-actions/` is untouched: it has **zero** runtime advisories (its 36 findings are all dev-only lint/test tooling behind major upgrades).

## Verification

- **22 suites / 49 tests pass**
- `next build` succeeds
- lint unchanged (3 pre-existing `no-console` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)